### PR TITLE
Add glob matching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,14 +1,3 @@
-[root]
-name = "cargo-testify"
-version = "0.1.0"
-dependencies = [
- "clap 2.26.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "error-chain 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "notify 2.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "notify-rust 3.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
 [[package]]
 name = "aho-corasick"
 version = "0.6.3"
@@ -79,6 +68,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "bytes"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "cargo-testify"
+version = "0.2.0"
+dependencies = [
+ "clap 2.26.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "error-chain 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "notify 2.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "notify-rust 3.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "cfg-if"
@@ -165,6 +166,11 @@ dependencies = [
 [[package]]
 name = "gcc"
 version = "0.3.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "glob"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -524,6 +530,7 @@ dependencies = [
 "checksum fsevent 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)" = "dfe593ebcfc76884138b25426999890b10da8e6a46d01b499d7c54c604672c38"
 "checksum fsevent-sys 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "1a772d36c338d07a032d5375a36f15f9a7043bf0cb8ce7cee658e037c6032874"
 "checksum gcc 0.3.53 (registry+https://github.com/rust-lang/crates.io-index)" = "e8310f7e9c890398b0e80e301c4f474e9918d2b27fca8f48486ca775fa9ffc5a"
+"checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
 "checksum inotify 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e8458c07bdbdaf309c80e2c3304d14c3db64e7465d4f07cf589ccb83fd0ff31a"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3b37545ab726dd833ec6420aaba8231c5b320814b9029ad585555d2a03e94fbf"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ include = [
 travis-ci = { repository = "greyblake/cargo-testify", branch = "master" }
 
 [dependencies]
+glob = "0.2"
 notify = "^2.5.0"
 regex = "0.2"
 error-chain = "0.10.0"

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ To display notification in the Desktop environment `notify-send` (Linux) or `osa
 
 ## Watched files
 
-* `src/*`
-* `tests/*`
+* `src/**/*.rs`
+* `tests/**/*.rs`
 * `Cargo.toml`
 * `Cargo.lock`
 * `build.rs`

--- a/src/config.rs
+++ b/src/config.rs
@@ -21,7 +21,7 @@ pub struct ConfigBuilder<'a> {
 
 impl<'a> ConfigBuilder<'a> {
     pub fn new() -> Self {
-        let defaults_pattenrs = vec![
+        let default_patterns = vec![
             "src/**/*.rs",
             "tests/**/*.rs",
             "Cargo.toml",
@@ -33,7 +33,7 @@ impl<'a> ConfigBuilder<'a> {
             ignore_duration: Duration::from_millis(300),
             project_dir: None,
             cargo_test_args: vec![],
-            patterns: defaults_pattenrs,
+            patterns: default_patterns,
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -54,18 +54,9 @@ impl<'a> ConfigBuilder<'a> {
 
     pub fn build(self) -> Result<Config<'a>> {
         let project_dir = self.project_dir.ok_or(ErrorKind::ProjectDirMissing)?;
-        let patterns = self.patterns
+        let patterns: Vec<Pattern> = self.patterns
             .iter()
-            .map(|p| {
-                let total_pattern = if !p.starts_with('/') {
-                    // TODO Handle OsString -> String conversion error
-                    let escaped_project_dir = Pattern::escape(&project_dir.clone().into_os_string().into_string().expect("Non UTF-8 project path"));
-                    escaped_project_dir + "/" + p
-                } else {
-                    p.to_string()
-                };
-                Pattern::new(&total_pattern).map_err(|e| e.into())
-            })
+            .map(|p| Pattern::new(p).map_err(|e| e.into()))
             .collect::<Result<_>>()?;
 
         let config = Config {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -2,4 +2,8 @@ error_chain! {
     errors {
         ProjectDirMissing { description("project directory is missing") }
     }
+
+    foreign_links {
+        PatternError(::glob::PatternError);
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@ pub fn run() {
                  .short("i")
                  .long("include")
                  .takes_value(true)
-                 .help("Comma separated list of include pattern"))
+                 .help("Comma separated list of include pattern in addition to the predefined default patterns"))
             .arg(Arg::with_name("cargo_test_args")
                  .multiple(true)
                  .last(true))

--- a/src/reactor.rs
+++ b/src/reactor.rs
@@ -151,7 +151,7 @@ fn notify(report: Report) {
 }
 
 /// Should changes in `path` file trigger running the test suite?
-fn filter_allows(project_dir: &Path, patterns: &[Pattern], mut path: &Path) -> bool {
+fn filter_allows<'a>(project_dir: &'a Path, patterns: &[Pattern], mut path: &'a Path) -> bool {
     const MATCH_OPTIONS: MatchOptions = MatchOptions {
         case_sensitive: true,
         require_literal_separator: false,


### PR DESCRIPTION
Tracking issue: #7 

- Add glob matching with defaults patterns:
  - `Cargo.toml`
  - `Cargo.lock`
  - `src/**/*.rs`
  - `tests/**/*.rs`
  - `build.rs`
- Add `--include` option to add custom patterns.