### PR TITLE
Remove unnecessary cloning of str

### DIFF
--- a/src/reactor.rs
+++ b/src/reactor.rs
@@ -127,15 +127,15 @@ impl Reactor {
                 let exit_status = child
                     .wait()
                     .expect("failed to wait for child process `cargo test`");
-                let stdout_output = stdout_buffer.lock().unwrap().clone();
-                let stderr_output = stderr_buffer.lock().unwrap().clone();
+                let stdout_output = stdout_buffer.lock().unwrap();
+                let stderr_output = stderr_buffer.lock().unwrap();
 
                 let report = self.report_builder.identify(
                     exit_status.success(),
                     &stdout_output,
                     &stderr_output,
                 );
-                notify(report)
+                notify(&report)
             }
             Err(err) => {
                 eprintln!("Failed to spawn `cargo test`");
@@ -146,7 +146,7 @@ impl Reactor {
     }
 }
 
-fn notify(report: Report) {
+fn notify(report: &Report) {
     let icon = match report.outcome {
         Outcome::TestsPassed => "face-angel",
         Outcome::TestsFailed | Outcome::CompileError => "face-angry",
@@ -155,8 +155,8 @@ fn notify(report: Report) {
         .summary(report.title())
         .icon(icon)
         .finalize();
-    if let Some(detail) = report.detail {
-        notification.body(&detail);
+    if let Some(ref detail) = report.detail {
+        notification.body(detail);
     }
     notification.show().expect("unable to send notification");
 }

--- a/src/report.rs
+++ b/src/report.rs
@@ -11,12 +11,12 @@ pub enum Outcome {
     CompileError,
 }
 
-pub struct Report {
+pub struct Report<'a> {
     pub outcome: Outcome,
-    pub detail: Option<String>,
+    pub detail: Option<&'a str>,
 }
 
-impl Report {
+impl<'a> Report<'a> {
     pub fn title(&self) -> &'static str {
         match self.outcome {
             Outcome::TestsPassed => "Tests passed",

--- a/src/report_builder.rs
+++ b/src/report_builder.rs
@@ -22,9 +22,14 @@ impl ReportBuilder {
         }
     }
 
-    pub fn identify(&self, process_success: bool, stdout: &str, stderr: &str) -> Report {
+    pub fn identify<'a>(
+        &self,
+        process_success: bool,
+        stdout: &'a str,
+        stderr: &'a str,
+    ) -> Report<'a> {
         if process_success {
-            let detail = self.result_re.find(stdout).map(|m| m.as_str().to_string());
+            let detail = self.result_re.find(stdout).map(|m| m.as_str());
             Report {
                 outcome: Outcome::TestsPassed,
                 detail,
@@ -33,10 +38,10 @@ impl ReportBuilder {
             match self.result_re.find(stdout) {
                 Some(matched) => Report {
                     outcome: Outcome::TestsFailed,
-                    detail: Some(matched.as_str().to_string()),
+                    detail: Some(matched.as_str()),
                 },
                 None => {
-                    let detail = self.error_re.find(stderr).map(|m| m.as_str().to_string());
+                    let detail = self.error_re.find(stderr).map(|m| m.as_str());
                     Report {
                         outcome: Outcome::CompileError,
                         detail,


### PR DESCRIPTION
Instead of cloning the `stdout` and `stderr` several times, we can use references. This should in theory make it faster.